### PR TITLE
Fix #52. Get rid of horizontal scrolling

### DIFF
--- a/_includes/venue-section.html
+++ b/_includes/venue-section.html
@@ -16,9 +16,5 @@
 	</div><!--//container-->
 </section><!--//venue-section-->
 <section id="venue-map-section" class="venue-map-section">
-    <div class="row">
-        <div class="col-md-12">
-	        <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3806.3114333137555!2d78.34757171434!3d17.444801888044285!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x3bce0a03f17ff82b%3A0x9d02e89b98deb496!2sIIIT%20Hyderabad!5e0!3m2!1sen!2sin!4v1570339090084!5m2!1sen!2sin" width="100%" height="400px" frameborder="0" allowfullscreen></iframe>	
-        </div>
-    </div>
+	<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3806.3114333137555!2d78.34757171434!3d17.444801888044285!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x3bce0a03f17ff82b%3A0x9d02e89b98deb496!2sIIIT%20Hyderabad!5e0!3m2!1sen!2sin!4v1570339090084!5m2!1sen!2sin" width="100%" height="400px" frameborder="0" allowfullscreen></iframe>	
 </section>


### PR DESCRIPTION
Hello!

Horizontal scrolling appears due to a block with a map (`.venue-map-section`). Inside it is the `.row` block, which is not wrapped in a Bootstrap container. And since `.row` has negative side margins, the width of the content becomes wider than the screen.

I see three solutions:

1) Wrap `.row` in` .container-fluid`. Then the HTML layoit will be completed and the horizontal scroll will disappear, but a padding of 15px will appear on the sides. This padding can be removed with additional styles.

2) Add one CSS property. This solution is shorter than the first, but the HTML construction remains incomplete.
```
.venue-map-section {
	overflow: hidden;
}
```

3) Remove the Bootstrap row with the column inside.. Since the meaning of the map block is to occupy the entire width of the screen, and inside the block there is only a frame with a map, I propose doing without the Bootstrap grid here .

This PR contains just the third solution.

Before:
![map-before](https://user-images.githubusercontent.com/3881568/66691429-90cb4180-ec96-11e9-952c-c14a531e2f1d.png)

After:
![map-after](https://user-images.githubusercontent.com/3881568/66691431-9759b900-ec96-11e9-863d-bb87a6b0a15d.png)

