### PR TITLE
changing the start url

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "background_color": "#333333",
   "display": "standalone",
   "Scope": "/",
-  "start_url": "/?utm=web_app",
+  "start_url": "https://pyconf.hydpy.org/2019/?utm=web_app",
   "icons": [
     {
       "src": "assets/images/icons/icon-72x72.png",


### PR DESCRIPTION
This can be the culprit why app is not getting the install banner.

Either this value or `/2019` prefix should also work.