### PR TITLE
Added 'more' nav dropdown item and fixed navigation back to main page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,7 +16,17 @@
 								<li class="nav-item" itemprop="name">
 									<a itemprop="url" class="nav-link scrollto" href="index.html{{ navitem.href }}">{{ navitem.item }}</a>
 								</li>
-							{% endfor %}
+              {% endfor %}
+              
+              <!-- More Dropdown link -->
+              <li class="nav-item dropdown" itemprop="name">
+                <a itemprop="url" class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">More</a>
+                <div class="dropdown-menu">
+                    <a class="dropdown-item" href="volunteer.html">Volunteer</a>
+                    <a class="dropdown-item" href="coc.html">Code of Conduct</a>
+                    <a class="dropdown-item" href="faq.html">FAQ</a>
+                </div>
+              </li>
 						</ul><!--//nav-->
 					</div><!--//navabr-collapse-->
 

--- a/_sass/theme/_base.scss
+++ b/_sass/theme/_base.scss
@@ -1,6 +1,12 @@
 /* ============= Base ============= */
 
 /*********** Theme Generic **********/
+
+/* ===== Smooth scrolling ====== */
+html {
+  scroll-behavior: smooth;
+}
+
 body {
     font-family: 'Roboto', sans-serif;
     -webkit-font-smoothing: antialiased;

--- a/_sass/theme/_home.scss
+++ b/_sass/theme/_home.scss
@@ -15,8 +15,16 @@
 	.logo-icon {
 		height: 48px;
 		width: auto;
-	}
+  }
 
+
+  
+  @media (min-width: 768px) {
+    li.nav-item.dropdown:hover .dropdown-menu {
+      display: block;
+      margin-top: 0;
+    }
+  }
 }
 
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -8,11 +8,6 @@ $(document).ready(function() {
     
     /* ===== Smooth scrolling ====== */
 	$('a.scrollto').on('click', function(e){
-        //store hash
-        var target = this.hash;    
-        e.preventDefault();
-		$('body').scrollTo(target, 800, {offset: -60, 'axis':'y'});
-		
 		//Collapse mobile menu after clicking
 		if ($('.navbar-collapse').hasClass('show')){
 			$('.navbar-toggler').trigger('click');


### PR DESCRIPTION
closes #73 
closes #72 

**Note**
I changed the smooth scroll behavior to be CSS instead of JS. This means that **Edge** and **Internet explorer** will not support smooth scroll with CSS. 

_If Internet explorer support is required,_ I can revisit this and change it so that the JS simply checks which page we're currently on and then preventDefault only if on the index page.