### PR TITLE
Fix #78. Set transition for specific CSS properties instead of `all`

### DIFF
--- a/_sass/theme.scss
+++ b/_sass/theme.scss
@@ -1,5 +1,5 @@
-/*************************** Theme Colours****************************/
-// Define theme colour scheme
+/*************************** Theme Colors ****************************/
+// Define theme color scheme
 $theme-color-primary: #098dcf;
 $theme-color-secondary: #EC645E;
 $theme-text-color-primary: #141c25;
@@ -13,8 +13,10 @@ $theme-color-tick: #5ab66e;
 $smoky-white: #f5f5f5;
 $single-col-max: 800px;
 
-/*************************** Variables Section. *****************************/
+/*************************** Variables Section *****************************/
 // Create variables to override the default value for variables used in the Bootstrap SCSS files.
+
+$btn-transition: color .4s ease-in-out, background-color .4s ease-in-out, border-color .4s ease-in-out, box-shadow .4s ease-in-out;
 
 $gray-100: lighten($theme-text-color-secondary, 65%);
 $gray-200: lighten($theme-text-color-secondary, 55%);
@@ -27,8 +29,8 @@ $gray-800: lighten($theme-text-color-secondary, 10%);
 $gray-900: $theme-text-color-primary;
 
 $theme-colors: (
-  "primary":  $theme-color-primary, 
-  "secondary": $theme-text-color-secondary, 
+  "primary":  $theme-color-primary,
+  "secondary": $theme-text-color-secondary,
 );
 
 /*************************** Import Bootstrap  *****************************/

--- a/_sass/theme/_base.scss
+++ b/_sass/theme/_base.scss
@@ -37,7 +37,6 @@ a.theme-link {
 .btn {
 	font-weight: 700;
 	padding: 0.6rem 1.25rem;
-	@include transition (all 0.4s ease-in-out);
 	border: none;
 	font-family: 'Montserrat', sans-serif;
 }
@@ -81,7 +80,7 @@ a.theme-link {
 }
 
 #topcontrol {
-    @include transition (all 0.4s ease-in-out);
+    @include transition(#{$btn-transition}, opacity .4s ease-in-out);
     background: $theme-text-color-secondary;
     color: #fff;
     text-align: center;
@@ -94,7 +93,7 @@ a.theme-link {
     padding-top: 0.5rem;
     font-weight: 300;
     font-size: 1rem;
-    
+
     &:hover {
         background: darken($theme-bg-primary, 10%);
         color: #fff;

--- a/_sass/theme/_home.scss
+++ b/_sass/theme/_home.scss
@@ -3,7 +3,7 @@
 .header {
 	padding-top: 0.5rem;
 	padding-bottom: 0.5rem;
-	@include transition (all 0.4s ease-in-out);
+//	@include transition (all 0.4s ease-in-out);
 	z-index: 100;
 	min-height: 60px;
 	background: none;


### PR DESCRIPTION
Fix #78. 

### Before
![hydpyconf2019-header-jumping](https://user-images.githubusercontent.com/3881568/68014011-babcc600-fc8e-11e9-907d-897513f72109.gif)

### After
![hydpyconf2019-header-jumping-fixed](https://user-images.githubusercontent.com/3881568/68014003-b42e4e80-fc8e-11e9-85a1-e0692c4d183d.gif)

### Source of problems

Currently `.header` in `_home.scss`, `.btn` and `#topcontrol` in `_base.scss` have this code:
```scss
@include transition (all 0.4s ease-in-out);
```
But `all` creates unpredictable problems, such as moving the right edge of the header when opening and closing modal windows. It is better to list in the `transition` property only those CSS properties that are really necessary. 

### Solution

1. Comment out the `transition` property for the `.header`. Currently it looks unused, but it creates unwanted effects. When we find out what CSS header properties should be "transitionable", we can uncomment this line and list the necessary properties instead of `all`.

2. To override the `transition` property  for the `.btn` class, it is better to change the `$btn-transition` variable that Bootstrap uses.

3. The script for `#topcontrol` changes only the `opacity` property. Other properties do not change, but just in case, I also added a standard Bootstrap set for the `transition`: `color`, `background-color`, `border-color` and `box-shadow`.
