### PR TITLE
Enable Talk and Speaker description links in Talks Schedule

### DIFF
--- a/_data/schedule/talks.yml
+++ b/_data/schedule/talks.yml
@@ -16,7 +16,7 @@
     time: "9:45AM - 10:45AM"
     type: 'keynote'
     tracks:
-      - {title: "Opening Keynote: ",speaker: "Dr. Sarabjot Singh Anand",description: "",category: "",audience_type: "",venue: "TBD"}
+      - {title: "Opening Keynote",speaker: "sarabjot_singh",description: "",category: "",audience_type: "",venue: "TBD"}
 
   -
     time: "10:45AM - 11:15AM"
@@ -78,4 +78,4 @@
     time: "5:00PM - 6:00PM"
     type: 'keynote'
     tracks:
-      - {title: "Closing Keynote", speaker: "Zainab Bawa", venue: "TBD"}
+      - {title: "Closing Keynote", speaker: "zainab_bawa", venue: "TBD"}

--- a/_includes/link-speaker.html
+++ b/_includes/link-speaker.html
@@ -1,8 +1,8 @@
-									{% unless track.speaker == "TBD" or track.speaker == "" %}
-										{% assign speaker = site.data.speakers[ track.speaker ] %}
-										{% if speaker %}
-											<div class="desc">By: <a class="link" href="#modal_speaker" data-toggle="modal" data-speaker="{{ track.speaker }}">{{ speaker.name }}</a></div>
-										{% else %}
-											<div class="desc">By: {{ track.speaker }}</div>
-										{% endif %}
-									{% endunless %}
+{% unless track.speaker == "" %}
+	{% assign speaker = site.data.speakers[ track.speaker ] %}
+	{% if speaker %}
+		<div class="desc">By: <a class="link" href="#modal_speaker" data-toggle="modal" data-speaker="{{ track.speaker }}">{{ speaker.name }}</a></div>
+	{% else %}
+		<div class="desc">By: {{ track.speaker }}</div>
+	{% endif %}
+{% endunless %}

--- a/_includes/schedule-section.html
+++ b/_includes/schedule-section.html
@@ -62,7 +62,7 @@
 						{% for track in workshop.tracks %}
 							<div class="col-md-8">
 								<div class="content">
-									<h3 class="title mb-3">{% include link-workshop.html %}</h3>
+									<h3 class="title mb-3">{{ track.title }}</h3>
 								</div><!--//content-->
 							</div>
 						{% endfor %}
@@ -93,14 +93,8 @@
 							{% assign colwidth = 8 | divided_by: forloop.length %}
 							<div class="col-md-{{ colwidth }}">
 								<div class="content">
-									<h3 class="title mb-3">{{ track.title}}</h3>
-
-									<!-- Remove this once we speaker data -->
-									<div class="desc">By: {{ track.speaker }}</div>
-									<!-- link speaker
-										Uncomment this once we get the speaker data
-									-->
-									<!-- {% include link-speaker.html %} -->
+									<h3 class="title mb-3">{% include link-workshop.html %}</h3>
+									{% include link-speaker.html %}
 									<div class="badge badge-secondary"> Track {{ forloop.index }}</div>
 
 								</div><!--//content-->


### PR DESCRIPTION
This change enables speaker and Talk description links for showing content modals for Talk schedule.